### PR TITLE
Hyprland v0.46.x Support

### DIFF
--- a/plugin/src/main.cpp
+++ b/plugin/src/main.cpp
@@ -185,7 +185,7 @@ void on_render(void* thisptr, SCallbackInfo& info, std::any args) {
         } break;
         case eRenderStage::RENDER_PRE_WINDOWS: {
             // CBox box = CBox(50, 50, 100.0, 100.0);
-            // g_pHyprOpenGL->renderRectWithBlur(&box, CColor(0.3, 0.0, 0.0, 0.3));
+            // g_pHyprOpenGL->renderRectWithBlur(&box, CHyprColor(0.3, 0.0, 0.0, 0.3));
             overview_enabled = false;
             g_go.render();
             overview_enabled = true;

--- a/plugin/src/overview.cpp
+++ b/plugin/src/overview.cpp
@@ -107,7 +107,7 @@ void OverviewWorkspace::render_top_layers(timespec* time) {
     // }
 }
 
-void OverviewWorkspace::render_border(CBox bbox, CColor col, int border_size) {
+void OverviewWorkspace::render_border(CBox bbox, CHyprColor col, int border_size) {
     bbox.expand(-border_size);
     bbox.round();
     bbox.w = std::max(bbox.w, 1.0);
@@ -126,8 +126,8 @@ void GridOverview::init() {
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, BORDER_SIZE_CONFIG_NAME)->getDataStaticPtr();
     static auto* const* GAP_SIZE =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, GAP_SIZE_CONFIG_NAME)->getDataStaticPtr();
-    cursor_ws_border = CColor(**CURSOR_WS_BORDER);
-    focus_border = CColor(**FOCUS_BORDER);
+    cursor_ws_border = CHyprColor(**CURSOR_WS_BORDER);
+    focus_border = CHyprColor(**FOCUS_BORDER);
     border_size = **BORDER_SIZE;
 
     auto m = g_pCompositor->getMonitorFromCursor();
@@ -189,7 +189,7 @@ void GridOverview::render() {
     g_pHyprOpenGL->m_RenderData.clipBox = box;
     g_pHyprOpenGL->m_RenderData.renderModif.enabled = true;
 
-    g_pHyprOpenGL->renderRectWithBlur(&box, CColor(0.0, 0.0, 0.0, 1.0));
+    g_pHyprOpenGL->renderRectWithBlur(&box, CHyprColor(0.0, 0.0, 0.0, 1.0));
 
     for (auto& ow : workspaces) {
         ow.render(box, &time);

--- a/plugin/src/overview.hpp
+++ b/plugin/src/overview.hpp
@@ -16,7 +16,7 @@ class OverviewWorkspace {
     void render_hyprland_wallpaper();
     void render_bg_layers(timespec* time);
     void render_top_layers(timespec* time);
-    void render_border(CBox bbox, CColor col, int border_size);
+    void render_border(CBox bbox, CHyprColor col, int border_size);
 };
 
 class GridOverview {
@@ -24,8 +24,8 @@ class GridOverview {
     std::string activity;
     std::vector<OverviewWorkspace> workspaces;
     CBox box;
-    CColor cursor_ws_border;
-    CColor focus_border;
+    CHyprColor cursor_ws_border;
+    CHyprColor focus_border;
     int border_size;
 
     void init();

--- a/plugin/src/utils.cpp
+++ b/plugin/src/utils.cpp
@@ -42,7 +42,7 @@ std::thread sock_thread;
 void err_notif(std::string msg) {
     msg = "[hyprkool] " + msg;
     std::cerr << msg << std::endl;
-    HyprlandAPI::addNotification(PHANDLE, msg, CColor{1.0, 0.2, 0.2, 1.0}, 5000);
+    HyprlandAPI::addNotification(PHANDLE, msg, CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
 }
 void throw_err_notif(std::string msg) {
     err_notif(msg);


### PR DESCRIPTION
This PR will add support for Hyprland v0.46.x. Currently, I've fixed the compile-time issues (the `CColor` class was renamed to `CHyprColor` upstream due to the new `hyprgraphics` library) and the plugin now builds and installs, but the overview does not render properly (it toggles properly, but just displays the wallpaper). I'll convert this to a full PR once I (or anyone else who wants to work on it) fix this issue, and any other issues found.

Current status:
- [x] Builds against Hyprland v0.46.x
- [x] Can be loaded without crashing Hyprland
- [x] Workspace switching works
    - [x] Workspace switching animations work
- [x] Activity switching works
- [ ] Overview works