### PR TITLE
nix: remove inefficient double copy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,10 @@
           pname = plugin-manifest.name;
           version = manifest.version;
 
-          src = ./.;
+          src = builtins.path {
+            path = ./.;
+            name = "hyprkool-source";
+          };
 
           dontUseCmakeConfigure = true;
           dontUseMesonConfigure = true;


### PR DESCRIPTION
fixes the nix warning: `Performing inefficient double copy of path '«github:thrombe/hyprkool/...`